### PR TITLE
fix(lib): exclude *.ngfactory.ts, *.ngsummary.json

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,3 @@
+.ng-aot/
+*.ngfactory.js
+*.ngsummary.json

--- a/lib/package.json
+++ b/lib/package.json
@@ -24,8 +24,8 @@
     "node": ">= 4.2.1",
     "npm": ">= 3"
   },
-  "main": "src/index.js",
-  "typings": "src/index.d.ts",
+  "main": "index.js",
+  "typings": "index.d.ts",
   "dependencies": {
     "halfred": "^1.0.0"
   },

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "angularCompilerOptions": {
-    "genDir": "../dist/ng-hal",
-    "entryModule": "./src/hal.module#HalModule"
+    "entryModule": "./src/hal.module#HalModule",
+    "genDir": "./.ng-aot"
   },
   "buildOnSave": false,
   "compileOnSave": false,
@@ -11,12 +11,14 @@
     "moduleResolution": "node",
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "noEmitHelpers": true,
-    "noImplicitAny": true,
+    "noEmitOnError": true,
+    "noImplicitAny": false,
+    "stripInternal": true,
     "baseUrl": "",
-    "rootDir": "",
+    "rootDir": "./src",
     "outDir": "../dist/ng-hal",
     "types": [
       "core-js",
@@ -31,6 +33,9 @@
       "es2015"
     ]
   },
+  "include": [
+    "src"
+  ],
   "exclude": [
     "node_modules",
     "dist",
@@ -38,9 +43,5 @@
     "**/*.ngfactory.ts",
     "**/*.shim.ts",
     "**/*.spec.ts"
-  ],
-  "files": [
-    "./src/index.ts",
-    "./src/typings/halfred.d.ts"
   ]
 }


### PR DESCRIPTION
- *.metadata.json must be included in the distributable package of an AoT-ready library
- *.ngfactory.ts and *.ngsummary.json should not be included, since they may cause compile errors for consumers

resolves #18 