### PR TITLE
Return an empty object on empty 204s

### DIFF
--- a/src/lib/src/parser/parser.ts
+++ b/src/lib/src/parser/parser.ts
@@ -15,7 +15,7 @@ import { InternalResourceWrapper } from './internal-resource-wrapper';
 export class Parser {
 
   public parse(input: any): Resource {
-    return new InternalResourceWrapper(halfredParse(input));
+    return new InternalResourceWrapper(halfredParse(input) || {});
   }
 
 }


### PR DESCRIPTION
PR to fix an issue on empty 204 responses.

> TypeError: Cannot read property '_links' of null